### PR TITLE
feat: support split font files for weights over the 65535 glyph limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"dotenv": "^16.6.1",
 		"fastify": "^5.7.4",
 		"fastify-metrics": "^12.1.0",
+		"fonteditor-core": "^2.6.3",
 		"fontkit": "^2.0.4",
 		"ioredis": "^5.6.1",
 		"pg": "^8.16.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ importers:
       fastify-metrics:
         specifier: ^12.1.0
         version: 12.1.0(fastify@5.7.4)
+      fonteditor-core:
+        specifier: ^2.6.3
+        version: 2.6.3
       fontkit:
         specifier: ^2.0.4
         version: 2.0.4
@@ -912,6 +915,13 @@ packages:
         integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==,
       }
 
+  "@xmldom/xmldom@0.8.15":
+    resolution:
+      {
+        integrity: sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==,
+      }
+    engines: { node: ">=10.0.0" }
+
   abstract-logging@2.0.1:
     resolution:
       {
@@ -1422,6 +1432,12 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+
+  fonteditor-core@2.6.3:
+    resolution:
+      {
+        integrity: sha512-YUryIKjkenjZ41E7JvM3V+02Ak4mTHDDTwBWgs9KBzypzHqLZHuua1UDRevZNTKawmnq1dbBAa70Jddl2+F4FQ==,
+      }
 
   fontkit@2.0.4:
     resolution:
@@ -3383,6 +3399,8 @@ snapshots:
 
   "@types/uuid@9.0.8": {}
 
+  "@xmldom/xmldom@0.8.15": {}
+
   abstract-logging@2.0.1: {}
 
   acorn@8.15.0: {}
@@ -3647,6 +3665,10 @@ snapshots:
       safe-regex2: 5.0.0
 
   follow-redirects@1.15.9: {}
+
+  fonteditor-core@2.6.3:
+    dependencies:
+      "@xmldom/xmldom": 0.8.15
 
   fontkit@2.0.4:
     dependencies:

--- a/src/bootstrap/fontNoMin.js
+++ b/src/bootstrap/fontNoMin.js
@@ -176,7 +176,7 @@ async function regenerateAllStaticFont(
 				fontName: ff_name, // 字型名稱（資料夾名稱）
 				weight: support_weights, // 字型的 weight（檔案名稱中的數字）
 			};
-			//讀字型檔案，取出所有支援的字型（分割檔取聯集）
+			// union of every split file of this weight
 			const charArray = getSupportedChars(ff_name, support_weights);
 			if (charArray === null) {
 				logger.warn(`讀取字型檔案失敗！${ff_name} ${support_weights}`);

--- a/src/bootstrap/fontNoMin.js
+++ b/src/bootstrap/fontNoMin.js
@@ -2,7 +2,7 @@
 //依照字頻表分裝檔案 (開機時重切)
 import { db } from "../utils/database.js";
 import { logger } from "../utils/logger.js";
-import { readFontBuffer } from "../utils/read-font-file/readFontBuffer.js";
+import { getSupportedChars } from "../utils/read-font-file/readFontBuffer.js";
 import { Worker } from "worker_threads";
 import { Redis } from "ioredis";
 import dotenv from "dotenv";
@@ -176,17 +176,12 @@ async function regenerateAllStaticFont(
 				fontName: ff_name, // 字型名稱（資料夾名稱）
 				weight: support_weights, // 字型的 weight（檔案名稱中的數字）
 			};
-			//讀字型檔案，取出所有支援的字型
-			const readFile_res = await readFontBuffer(ff_name, support_weights, true);
-			if (readFile_res.success == false) {
+			//讀字型檔案，取出所有支援的字型（分割檔取聯集）
+			const charArray = getSupportedChars(ff_name, support_weights);
+			if (charArray === null) {
 				logger.warn(`讀取字型檔案失敗！${ff_name} ${support_weights}`);
 				continue;
 			}
-			const fontfile = readFile_res.fontfile;
-			const supportedCodePoints = Array.from(fontfile.characterSet);
-			const charArray = supportedCodePoints
-				.map(cp => String.fromCodePoint(cp))
-				.filter(char => char !== "\x00");
 			logger.info(
 				`╔ ${ff_name} ${support_weights} 有 ${charArray.length} 個字`,
 			);

--- a/src/bootstrap/init.js
+++ b/src/bootstrap/init.js
@@ -75,7 +75,6 @@ async function insertFontTypes() {
 			// 讀取該資料夾內的所有檔案
 			const fontFiles = await readdir(itemPath);
 			for (const fontFile of fontFiles) {
-				// accepts `400.ttf` and split parts like `400-1.ttf`
 				const parsed = parseFontFileName(fontFile);
 				if (!parsed) {
 					skipped.push(fontFile);

--- a/src/bootstrap/init.js
+++ b/src/bootstrap/init.js
@@ -10,6 +10,7 @@ import { generateSitemap } from "../website/api.js";
 import { analyseFontsInBatches } from "../utils/read-font-file/analyseFonts.js";
 import { generateCSSMap } from "../website/generateCSSMap.js";
 import { logger } from "../utils/logger.js";
+import { parseFontFileName } from "../utils/read-font-file/readFontBuffer.js";
 const readdir = promisify(fs.readdir);
 const stat = promisify(fs.stat);
 
@@ -74,12 +75,13 @@ async function insertFontTypes() {
 			// 讀取該資料夾內的所有檔案
 			const fontFiles = await readdir(itemPath);
 			for (const fontFile of fontFiles) {
-				if (!/^\d+\.(ttf|otf)$/i.test(fontFile)) {
+				// accepts `400.ttf` and split parts like `400-1.ttf`
+				const parsed = parseFontFileName(fontFile);
+				if (!parsed) {
 					skipped.push(fontFile);
 					continue; // 不符合就跳過
 				}
-				const match_groups = fontFile.match(/^(\d+)\.(ttf|otf)$/i);
-				const weight = match_groups[1]; // 取得數字部分作為 weight
+				const weight = String(parsed.weight);
 				// 將資料夾名（font_name）和提取的 weight 存入 fontData
 				if (!fontWeightsMap.has(one_font_family)) {
 					//first time discover font family will enter this if
@@ -91,7 +93,7 @@ async function insertFontTypes() {
 					});
 				}
 				fontWeightsMap.get(one_font_family).add(parseInt(weight));
-				file_count++;
+				if (parsed.part === 0) file_count++;
 			}
 		}
 

--- a/src/public/admin-font-edit.html
+++ b/src/public/admin-font-edit.html
@@ -133,7 +133,7 @@
 								/>
 							</label>
 							<label data-super-admin-only hidden>
-								<span>重新上傳分割檔序號（留空為主檔）</span>
+								<span>重新上傳分割檔序號（留空為主檔，會清掉該字重舊的分割檔）</span>
 								<input
 									name="replacementPart"
 									type="number"

--- a/src/public/admin-font-edit.html
+++ b/src/public/admin-font-edit.html
@@ -132,6 +132,16 @@
 									placeholder="400"
 								/>
 							</label>
+							<label data-super-admin-only hidden>
+								<span>重新上傳分割檔序號（留空為主檔）</span>
+								<input
+									name="replacementPart"
+									type="number"
+									min="0"
+									max="99"
+									placeholder="0"
+								/>
+							</label>
 							<label class="wide file-drop" data-super-admin-only hidden>
 								<span>重新上傳原始字型檔</span>
 								<input

--- a/src/public/admin-font-upload.html
+++ b/src/public/admin-font-upload.html
@@ -50,6 +50,16 @@
 							/>
 						</label>
 						<label>
+							<span>分割檔序號（超過 65535 字的字型才需要，留空為主檔）</span>
+							<input
+								name="part"
+								type="number"
+								min="0"
+								max="99"
+								placeholder="0"
+							/>
+						</label>
+						<label>
 							<span>分類</span>
 							<select name="category" required>
 								<option value="sans-serif">sans-serif</option>

--- a/src/public/admin-font-upload.html
+++ b/src/public/admin-font-upload.html
@@ -50,7 +50,7 @@
 							/>
 						</label>
 						<label>
-							<span>分割檔序號（超過 65535 字的字型才需要，留空為主檔）</span>
+							<span>分割檔序號（超過 65535 字才需要；留空為主檔，上傳主檔會清掉該字重舊的分割檔）</span>
 							<input
 								name="part"
 								type="number"

--- a/src/public/assets/admin-font-edit.js
+++ b/src/public/assets/admin-font-edit.js
@@ -120,6 +120,7 @@ function fillForm(font) {
 	editForm.elements.authors.value = arrayToText(font.authors);
 	editForm.elements.format.value = font.format || "ttf";
 	editForm.elements.replacementWeight.value = font.weights?.[0] || "";
+	editForm.elements.replacementPart.value = "";
 	editForm.elements.fontFile.value = "";
 	renderDemoSentences(font.demoContentId || 1);
 	previewLink.href = font.fontUrl;
@@ -269,6 +270,7 @@ editForm.addEventListener("submit", async event => {
 			payload.fileBase64 = await fileToBase64(file);
 		} else {
 			delete payload.replacementWeight;
+			delete payload.replacementPart;
 		}
 
 		const res = await fetch(`/api/admin/fonts/${encodeURIComponent(fontId)}`, {

--- a/src/utils/generate-font/makeFont.js
+++ b/src/utils/generate-font/makeFont.js
@@ -1,9 +1,74 @@
 import path from "path";
 import fs from "fs";
 import subsetFont from "subset-font";
-import { readFontBuffer } from "../read-font-file/readFontBuffer.js";
+import { Font } from "fonteditor-core";
+import { getFontPartCharSets } from "../read-font-file/readFontBuffer.js";
 import { logger } from "../logger.js";
 const __dirname = import.meta.dirname;
+
+function sfntType(buffer) {
+	return buffer.toString("latin1", 0, 4) === "OTTO" ? "otf" : "ttf";
+}
+
+// Merge the requested glyphs of several split files into one sfnt.
+// Each part is subset first so fonteditor-core only parses a handful of glyphs.
+async function mergeFontParts(selected) {
+	let merged = null;
+	for (const { part, words } of selected) {
+		const sfnt = await subsetFont(fs.readFileSync(part.fullPath), words, {
+			targetFormat: "truetype",
+		});
+		const font = Font.create(sfnt, {
+			type: sfntType(sfnt),
+			hinting: false,
+			compound2simple: true,
+		});
+		if (!merged) {
+			merged = font;
+			continue;
+		}
+		const scale =
+			merged.get().head.unitsPerEm / font.get().head.unitsPerEm || 1;
+		merged.merge(font, { scale, adjustGlyf: false });
+	}
+	return merged.write({ type: "ttf", hinting: false, toBuffer: true });
+}
+
+// Pick the sfnt to subset from. Single-file weights are returned untouched;
+// split weights only merge the parts that actually own requested glyphs.
+async function loadSubsetSource(originalFontFamily, font_weight, words) {
+	const parts = getFontPartCharSets(originalFontFamily, font_weight);
+	if (parts.length === 0) return { success: false };
+	if (parts.length === 1) {
+		return { success: true, fontfile: fs.readFileSync(parts[0].fullPath) };
+	}
+	const needed = new Set(Array.from(words, char => char.codePointAt(0)));
+	const selected = [];
+	for (const part of parts) {
+		const owned = [];
+		for (const cp of needed) {
+			if (part.codePoints.has(cp)) {
+				owned.push(cp);
+				needed.delete(cp);
+			}
+		}
+		if (owned.length > 0) {
+			selected.push({
+				part,
+				words: owned.map(cp => String.fromCodePoint(cp)).join(""),
+			});
+		}
+	}
+	// No part owns any requested glyph: keep the old behaviour of emitting an empty subset.
+	if (selected.length === 0) {
+		return { success: true, fontfile: fs.readFileSync(parts[0].fullPath) };
+	}
+	if (selected.length === 1) {
+		return { success: true, fontfile: fs.readFileSync(selected[0].part.fullPath) };
+	}
+	return { success: true, fontfile: await mergeFontParts(selected) };
+}
+
 // generateFont: geneerate subset font and save to disk.
 async function generateFont(
 	originalFontFamily,
@@ -15,11 +80,12 @@ async function generateFont(
 ) {
 	try {
 		// 如果沒提供 buffer，就讀取字型檔
-		let type, success;
+		let success = true;
 		if (!fontfile) {
-			({ fontfile, type, success } = await readFontBuffer(
+			({ fontfile, success } = await loadSubsetSource(
 				originalFontFamily,
 				font_weight,
+				words,
 			));
 		}
 		if (!success) {

--- a/src/utils/generate-font/makeFont.js
+++ b/src/utils/generate-font/makeFont.js
@@ -2,19 +2,32 @@ import path from "path";
 import fs from "fs";
 import subsetFont from "subset-font";
 import { Font } from "fonteditor-core";
-import { getFontPartCharSets } from "../read-font-file/readFontBuffer.js";
+import {
+	listFontPartFiles,
+	getFontPartCharSets,
+} from "../read-font-file/readFontBuffer.js";
 import { logger } from "../logger.js";
 const __dirname = import.meta.dirname;
 
 function sfntType(buffer) {
+	// subset-font keeps CFF outlines for OTF input, so the subset can still be OTTO.
 	return buffer.toString("latin1", 0, 4) === "OTTO" ? "otf" : "ttf";
 }
 
-// Merge the requested glyphs of several split files into one sfnt.
-// Each part is subset first so fonteditor-core only parses a handful of glyphs.
+function isBlankGlyph(glyph) {
+	return (
+		glyph.unicode?.length > 0 &&
+		!(glyph.contours?.length > 0) &&
+		glyph.name !== ".notdef" &&
+		glyph.name !== ".null" &&
+		glyph.name !== "nonmarkingreturn"
+	);
+}
+
 async function mergeFontParts(selected) {
 	let merged = null;
 	for (const { part, words } of selected) {
+		// Subset each part first so fonteditor-core only has to parse the requested glyphs.
 		const sfnt = await subsetFont(fs.readFileSync(part.fullPath), words, {
 			targetFormat: "truetype",
 		});
@@ -27,46 +40,55 @@ async function mergeFontParts(selected) {
 			merged = font;
 			continue;
 		}
-		const scale =
-			merged.get().head.unitsPerEm / font.get().head.unitsPerEm || 1;
-		merged.merge(font, { scale, adjustGlyf: false });
+		// fonteditor-core rescales imported glyphs to the base unitsPerEm on its own.
+		merged.merge(font, { scale: true, adjustGlyf: false });
+		// merge() silently skips contour-less glyphs (spaces), which would drop their cmap entries.
+		const mergedTtf = merged.get();
+		const known = new Set(mergedTtf.glyf.flatMap(g => g.unicode ?? []));
+		for (const glyph of font.get().glyf) {
+			if (!isBlankGlyph(glyph)) continue;
+			glyph.unicode = glyph.unicode.filter(u => !known.has(u));
+			if (glyph.unicode.length > 0) mergedTtf.glyf.push(glyph);
+		}
 	}
 	return merged.write({ type: "ttf", hinting: false, toBuffer: true });
 }
 
-// Pick the sfnt to subset from. Single-file weights are returned untouched;
-// split weights only merge the parts that actually own requested glyphs.
+// Returns the sfnt to subset from, or null when the weight has no files.
 async function loadSubsetSource(originalFontFamily, font_weight, words) {
+	const files = listFontPartFiles(originalFontFamily, font_weight);
+	if (files.length === 0) {
+		logger.warn(`找不到字體: ${originalFontFamily} ${font_weight}`);
+		return null;
+	}
+	// Single-file weights skip the code point scan entirely.
+	if (files.length === 1) return fs.readFileSync(files[0].fullPath);
+
 	const parts = getFontPartCharSets(originalFontFamily, font_weight);
-	if (parts.length === 0) return { success: false };
-	if (parts.length === 1) {
-		return { success: true, fontfile: fs.readFileSync(parts[0].fullPath) };
+	if (parts.length === 0) {
+		logger.warn(`找不到字體: ${originalFontFamily} ${font_weight}`);
+		return null;
 	}
 	const needed = new Set(Array.from(words, char => char.codePointAt(0)));
 	const selected = [];
 	for (const part of parts) {
+		if (needed.size === 0) break;
 		const owned = [];
 		for (const cp of needed) {
-			if (part.codePoints.has(cp)) {
-				owned.push(cp);
-				needed.delete(cp);
-			}
+			if (part.codePoints.has(cp)) owned.push(cp);
 		}
-		if (owned.length > 0) {
-			selected.push({
-				part,
-				words: owned.map(cp => String.fromCodePoint(cp)).join(""),
-			});
-		}
+		if (owned.length === 0) continue;
+		for (const cp of owned) needed.delete(cp);
+		selected.push({
+			part,
+			words: owned.map(cp => String.fromCodePoint(cp)).join(""),
+		});
 	}
-	// No part owns any requested glyph: keep the old behaviour of emitting an empty subset.
-	if (selected.length === 0) {
-		return { success: true, fontfile: fs.readFileSync(parts[0].fullPath) };
+	// Nothing matched: emit an empty subset from the primary file, same as a single-file font would.
+	if (selected.length <= 1) {
+		return fs.readFileSync((selected[0]?.part ?? parts[0]).fullPath);
 	}
-	if (selected.length === 1) {
-		return { success: true, fontfile: fs.readFileSync(selected[0].part.fullPath) };
-	}
-	return { success: true, fontfile: await mergeFontParts(selected) };
+	return mergeFontParts(selected);
 }
 
 // generateFont: geneerate subset font and save to disk.
@@ -80,15 +102,10 @@ async function generateFont(
 ) {
 	try {
 		// 如果沒提供 buffer，就讀取字型檔
-		let success = true;
 		if (!fontfile) {
-			({ fontfile, success } = await loadSubsetSource(
-				originalFontFamily,
-				font_weight,
-				words,
-			));
+			fontfile = await loadSubsetSource(originalFontFamily, font_weight, words);
 		}
-		if (!success) {
+		if (!fontfile) {
 			return {
 				status: "failed",
 				message: "emfont can't read original font, please try again later.",

--- a/src/utils/read-font-file/allGlyphs.js
+++ b/src/utils/read-font-file/allGlyphs.js
@@ -1,13 +1,10 @@
-import { readFontBuffer } from "./readFontBuffer.js";
+import { getSupportedChars } from "./readFontBuffer.js";
 async function get_glyphs(ff_name, weights)
 {
-    const readFile_res = await readFontBuffer(ff_name, weights, true);
-    if (readFile_res.success == false) {
-        console.warn("讀取字型檔案失敗！");
+    const charArray = getSupportedChars(ff_name, weights);
+    if (charArray === null) {
+        throw new Error(`讀取字型檔案失敗！${ff_name} ${weights}`);
     }
-    const fontfile = readFile_res.fontfile;
-    const supportedCodePoints = Array.from(fontfile.characterSet);
-    const charArray = supportedCodePoints.map(cp => String.fromCodePoint(cp)).filter(char => char !== "\x00");
     return charArray;
 }
 

--- a/src/utils/read-font-file/readFontBuffer.js
+++ b/src/utils/read-font-file/readFontBuffer.js
@@ -5,10 +5,9 @@ import fs from "fs";
 const __dirname = import.meta.dirname;
 const __Font_storge_path_base = path.join(__dirname, "../../", "_data", "original-fonts"); //projectroot/src/_data/original-fonts/
 
-// One weight may be split into several files when the glyph count exceeds the
-// 65535 sfnt limit (e.g. 全字庫 TW-Kai + Ext-B + Plus). The primary file is
-// `<weight>.<ext>`; extra parts are `<weight>-<n>.<ext>` with n >= 1.
-const FONT_FILE_RE = /^(\d+)(?:-(\d+))?\.(ttf|otf)$/i;
+// A weight may span several files because one sfnt holds at most 65535 glyphs (e.g. 全字庫 TW-Kai + Ext-B + Plus).
+// Primary file is `<weight>.<ext>`, extra parts are `<weight>-<n>.<ext>` with n >= 1.
+const FONT_FILE_RE = /^(\d+)(?:-([1-9]\d*))?\.(ttf|otf)$/i;
 const FONT_EXTENSIONS = ["ttf", "otf"];
 
 function fontFileName(weight, part = 0, extension = "ttf") {
@@ -25,7 +24,7 @@ function parseFontFileName(fileName) {
     };
 }
 
-// Every file belonging to a weight, ordered by part index. ttf wins over otf for the same part.
+// Every file of a weight ordered by part index; ttf wins over otf when both exist for one part.
 function listFontPartFiles(originalFontFamily, font_weight) {
     const dir = path.join(__Font_storge_path_base, originalFontFamily);
     if (!fs.existsSync(dir)) return [];
@@ -40,28 +39,7 @@ function listFontPartFiles(originalFontFamily, font_weight) {
     return Array.from(byPart.values()).sort((a, b) => a.part - b.part);
 }
 
-/**
- * 讀取字型檔案
- * @param {string} originalFontFamily 字型資料夾名稱
- * @param {string} font_weight 字重檔名（不含副檔名）
- * @param {boolean} use_fontkit 是否使用 fontkit 解析
- * @returns {Promise<{success: boolean, fontfile?: Buffer|object, type?: string, parts?: Array<{part: number, type: string, fullPath: string, fontfile: Buffer|object}>}>}
- */
-async function readFontBuffer(originalFontFamily, font_weight, use_fontkit = false) {
-    const files = listFontPartFiles(originalFontFamily, font_weight);
-    if (files.length === 0) {
-        console.error("找不到字體:", path.join(__Font_storge_path_base, originalFontFamily, `${font_weight}.ttf`));
-        return { success: false };
-    }
-    const parts = files.map(file => ({
-        ...file,
-        fontfile: use_fontkit ? fontkit.openSync(file.fullPath) : fs.readFileSync(file.fullPath),
-    }));
-    // fontfile/type keep the single-file shape for existing callers; parts carries every split file.
-    return { fontfile: parts[0].fontfile, type: parts[0].type, parts, success: true };
-}
-
-// Cache of per-part code point sets, invalidated when any part file changes on disk.
+// Per-part code point sets, keyed by family/weight and invalidated when any part changes on disk.
 const partCharSetCache = new Map();
 
 function partsSignature(files) {
@@ -73,48 +51,47 @@ function partsSignature(files) {
         .join("|");
 }
 
-/**
- * 取得每個分割檔支援的碼位
- * @returns {Array<{part: number, type: string, fullPath: string, codePoints: Set<number>}>} 找不到字型時為空陣列
- */
+// Returns [] when the weight has no files or a file vanished mid-read (admin replacement in progress).
 function getFontPartCharSets(originalFontFamily, font_weight) {
-    const files = listFontPartFiles(originalFontFamily, font_weight);
-    if (files.length === 0) return [];
-    const cacheKey = `${originalFontFamily}/${font_weight}`;
-    const signature = partsSignature(files);
-    const cached = partCharSetCache.get(cacheKey);
-    if (cached && cached.signature === signature) return cached.parts;
-    const parts = files.map(file => ({
-        ...file,
-        codePoints: new Set(fontkit.openSync(file.fullPath).characterSet),
-    }));
-    partCharSetCache.set(cacheKey, { signature, parts });
-    return parts;
+    try {
+        const files = listFontPartFiles(originalFontFamily, font_weight);
+        if (files.length === 0) return [];
+        const cacheKey = `${originalFontFamily}/${font_weight}`;
+        const signature = partsSignature(files);
+        const cached = partCharSetCache.get(cacheKey);
+        if (cached && cached.signature === signature) return cached.parts;
+        const parts = files.map(file => ({
+            ...file,
+            codePoints: new Set(fontkit.openSync(file.fullPath).characterSet),
+        }));
+        partCharSetCache.set(cacheKey, { signature, parts });
+        return parts;
+    } catch (err) {
+        if (err.code === "ENOENT") return [];
+        throw err;
+    }
 }
 
-/**
- * 取得該字重所有分割檔支援字元的聯集
- * @returns {string[]|null} 找不到字型時為 null
- */
+// Union of every char supported by all parts of a weight; null when the weight has no files.
 function getSupportedChars(originalFontFamily, font_weight) {
     const parts = getFontPartCharSets(originalFontFamily, font_weight);
     if (parts.length === 0) return null;
-    const codePoints = new Set();
-    for (const { codePoints: partCodePoints } of parts) {
-        for (const cp of partCodePoints) codePoints.add(cp);
+    const seen = new Set();
+    const chars = [];
+    for (const { codePoints } of parts) {
+        for (const cp of codePoints) {
+            if (cp === 0 || seen.has(cp)) continue;
+            seen.add(cp);
+            chars.push(String.fromCodePoint(cp));
+        }
     }
-    return Array.from(codePoints)
-        .map(cp => String.fromCodePoint(cp))
-        .filter(char => char !== "\x00");
+    return chars;
 }
 
 export {
-    readFontBuffer,
     listFontPartFiles,
     getFontPartCharSets,
     getSupportedChars,
     fontFileName,
     parseFontFileName,
-    FONT_FILE_RE,
-    FONT_EXTENSIONS,
 };

--- a/src/utils/read-font-file/readFontBuffer.js
+++ b/src/utils/read-font-file/readFontBuffer.js
@@ -3,37 +3,118 @@ import path from "path";
 import * as fontkit from "fontkit";
 import fs from "fs";
 const __dirname = import.meta.dirname;
-const __Font_storge_path_base = path.join(__dirname, "../../","_data", "original-fonts"); //projectroot/src/_data/original-fonts/
+const __Font_storge_path_base = path.join(__dirname, "../../", "_data", "original-fonts"); //projectroot/src/_data/original-fonts/
+
+// One weight may be split into several files when the glyph count exceeds the
+// 65535 sfnt limit (e.g. 全字庫 TW-Kai + Ext-B + Plus). The primary file is
+// `<weight>.<ext>`; extra parts are `<weight>-<n>.<ext>` with n >= 1.
+const FONT_FILE_RE = /^(\d+)(?:-(\d+))?\.(ttf|otf)$/i;
+const FONT_EXTENSIONS = ["ttf", "otf"];
+
+function fontFileName(weight, part = 0, extension = "ttf") {
+    return part > 0 ? `${weight}-${part}.${extension}` : `${weight}.${extension}`;
+}
+
+function parseFontFileName(fileName) {
+    const match = fileName.match(FONT_FILE_RE);
+    if (!match) return null;
+    return {
+        weight: Number(match[1]),
+        part: match[2] ? Number(match[2]) : 0,
+        extension: match[3].toLowerCase(),
+    };
+}
+
+// Every file belonging to a weight, ordered by part index. ttf wins over otf for the same part.
+function listFontPartFiles(originalFontFamily, font_weight) {
+    const dir = path.join(__Font_storge_path_base, originalFontFamily);
+    if (!fs.existsSync(dir)) return [];
+    const byPart = new Map();
+    for (const name of fs.readdirSync(dir)) {
+        const parsed = parseFontFileName(name);
+        if (!parsed || parsed.weight !== Number(font_weight)) continue;
+        const existing = byPart.get(parsed.part);
+        if (existing && FONT_EXTENSIONS.indexOf(existing.type) <= FONT_EXTENSIONS.indexOf(parsed.extension)) continue;
+        byPart.set(parsed.part, { part: parsed.part, type: parsed.extension, fullPath: path.join(dir, name) });
+    }
+    return Array.from(byPart.values()).sort((a, b) => a.part - b.part);
+}
+
 /**
  * 讀取字型檔案
  * @param {string} originalFontFamily 字型資料夾名稱
  * @param {string} font_weight 字重檔名（不含副檔名）
  * @param {boolean} use_fontkit 是否使用 fontkit 解析
- * @returns {Promise<{success: boolean, fontfile?: Buffer|object, type?: string, error?: string}>}
+ * @returns {Promise<{success: boolean, fontfile?: Buffer|object, type?: string, parts?: Array<{part: number, type: string, fullPath: string, fontfile: Buffer|object}>}>}
  */
 async function readFontBuffer(originalFontFamily, font_weight, use_fontkit = false) {
-    // Construct the full path to the font file based on the family and variant
-    // extensions name may be ttf or otf. Try to find any of them
-    const file_found = [".ttf", ".otf"]
-        .map(ext => ({
-            ext: ext.slice(1),
-            fullPath: path.join(__Font_storge_path_base, originalFontFamily, `${font_weight}${ext}`)
-        }))
-        .find(({ fullPath }) => fs.existsSync(fullPath));
-    if (!file_found) {
+    const files = listFontPartFiles(originalFontFamily, font_weight);
+    if (files.length === 0) {
         console.error("找不到字體:", path.join(__Font_storge_path_base, originalFontFamily, `${font_weight}.ttf`));
         return { success: false };
-    } else {
-        let fontfile;
-        if (use_fontkit) {
-            fontfile = fontkit.openSync(file_found.fullPath);
-            //Opens a font file asynchronously, and returns a Promise with a font object
-            // fontfile is a fontkit object
-        } else {
-            fontfile = fs.readFileSync(file_found.fullPath);
-        }
-        return { fontfile, type: file_found.ext, success: true };
     }
+    const parts = files.map(file => ({
+        ...file,
+        fontfile: use_fontkit ? fontkit.openSync(file.fullPath) : fs.readFileSync(file.fullPath),
+    }));
+    // fontfile/type keep the single-file shape for existing callers; parts carries every split file.
+    return { fontfile: parts[0].fontfile, type: parts[0].type, parts, success: true };
 }
 
-export {readFontBuffer};
+// Cache of per-part code point sets, invalidated when any part file changes on disk.
+const partCharSetCache = new Map();
+
+function partsSignature(files) {
+    return files
+        .map(({ fullPath }) => {
+            const stat = fs.statSync(fullPath);
+            return `${fullPath}:${stat.size}:${stat.mtimeMs}`;
+        })
+        .join("|");
+}
+
+/**
+ * 取得每個分割檔支援的碼位
+ * @returns {Array<{part: number, type: string, fullPath: string, codePoints: Set<number>}>} 找不到字型時為空陣列
+ */
+function getFontPartCharSets(originalFontFamily, font_weight) {
+    const files = listFontPartFiles(originalFontFamily, font_weight);
+    if (files.length === 0) return [];
+    const cacheKey = `${originalFontFamily}/${font_weight}`;
+    const signature = partsSignature(files);
+    const cached = partCharSetCache.get(cacheKey);
+    if (cached && cached.signature === signature) return cached.parts;
+    const parts = files.map(file => ({
+        ...file,
+        codePoints: new Set(fontkit.openSync(file.fullPath).characterSet),
+    }));
+    partCharSetCache.set(cacheKey, { signature, parts });
+    return parts;
+}
+
+/**
+ * 取得該字重所有分割檔支援字元的聯集
+ * @returns {string[]|null} 找不到字型時為 null
+ */
+function getSupportedChars(originalFontFamily, font_weight) {
+    const parts = getFontPartCharSets(originalFontFamily, font_weight);
+    if (parts.length === 0) return null;
+    const codePoints = new Set();
+    for (const { codePoints: partCodePoints } of parts) {
+        for (const cp of partCodePoints) codePoints.add(cp);
+    }
+    return Array.from(codePoints)
+        .map(cp => String.fromCodePoint(cp))
+        .filter(char => char !== "\x00");
+}
+
+export {
+    readFontBuffer,
+    listFontPartFiles,
+    getFontPartCharSets,
+    getSupportedChars,
+    fontFileName,
+    parseFontFileName,
+    FONT_FILE_RE,
+    FONT_EXTENSIONS,
+};

--- a/src/website/admin.js
+++ b/src/website/admin.js
@@ -15,7 +15,10 @@ import { logger } from "../utils/logger.js";
 import { analyseFontsInBatches } from "../utils/read-font-file/analyseFonts.js";
 import { get_bullet, get_generated_static_floders } from "../bootstrap/init.js";
 import { regenerateAllStaticFont } from "../bootstrap/fontNoMin.js";
-import { fontFileName } from "../utils/read-font-file/readFontBuffer.js";
+import {
+	fontFileName,
+	listFontPartFiles,
+} from "../utils/read-font-file/readFontBuffer.js";
 import { generateCSSMap } from "./generateCSSMap.js";
 
 const redis = new Redis(process.env.REDIS_URL);
@@ -494,6 +497,10 @@ async function saveOriginalFontFile({
 	}
 	const fontDir = path.join(originalFontsDir, id);
 	const fontBuffer = Buffer.from(fileBase64, "base64");
+	const existingParts = listFontPartFiles(id, weight);
+	if (part > 0 && !existingParts.some(file => file.part === 0)) {
+		throw new Error(`Upload the primary file ${fontFileName(weight, 0, extension)} before part ${part}`);
+	}
 
 	await syncOriginalFontToMinio({
 		id,
@@ -508,16 +515,25 @@ async function saveOriginalFontFile({
 		fontBuffer,
 	);
 
+	// Uploading a primary file resets the weight, so stale split parts from a previous upload must go too.
+	const stale = [];
 	for (const oldExtension of fontExtensions) {
-		if (oldExtension === extension) continue;
-		await rm(path.join(fontDir, fontFileName(weight, part, oldExtension)), {
+		if (oldExtension !== extension) stale.push({ part, extension: oldExtension });
+	}
+	if (part === 0) {
+		for (const file of existingParts) {
+			if (file.part > 0) stale.push({ part: file.part, extension: file.type });
+		}
+	}
+	for (const file of stale) {
+		await rm(path.join(fontDir, fontFileName(weight, file.part, file.extension)), {
 			force: true,
 		});
 		await deleteOriginalFontFromMinio({
 			id,
 			weight,
-			part,
-			extension: oldExtension,
+			part: file.part,
+			extension: file.extension,
 		});
 	}
 }
@@ -561,7 +577,6 @@ function assertUploadPayload(body) {
 	if (!["ttf", "otf"].includes(ext)) {
 		throw new Error("Only ttf and otf fonts are supported");
 	}
-	normalizeFontPart(body.part);
 	if (!allowedCategories.has(body.category)) {
 		throw new Error("Invalid category");
 	}
@@ -639,11 +654,12 @@ function assertDemoSentencePayload(body) {
 async function saveFontRecord(body) {
 	const id = body.id.trim();
 	const weight = Number(body.weight);
+	const part = normalizeFontPart(body.part);
 	const extension = normalizeFontExtension(body.extension);
 	await saveOriginalFontFile({
 		id,
 		weight,
-		part: normalizeFontPart(body.part),
+		part,
 		extension,
 		fileBase64: body.fileBase64,
 	});
@@ -675,7 +691,7 @@ async function saveFontRecord(body) {
 			repo_url = EXCLUDED.repo_url,
 			authors = EXCLUDED.authors,
 			demo_content_id = EXCLUDED.demo_content_id,
-			format = EXCLUDED.format
+			format = CASE WHEN $16::boolean THEN EXCLUDED.format ELSE font_family.format END
 		`,
 		[
 			id,
@@ -693,6 +709,7 @@ async function saveFontRecord(body) {
 			normalizeTextArray(body.authors),
 			Number(body.demoContentId || 1),
 			extension,
+			part === 0,
 		],
 	);
 
@@ -719,7 +736,8 @@ async function updateFontRecord(id, body) {
 			id,
 			...replacementFont,
 		});
-		body.format = replacementFont.extension;
+		// Split parts may differ in extension; the download link follows the primary file.
+		if (replacementFont.part === 0) body.format = replacementFont.extension;
 	}
 
 	await db.query(

--- a/src/website/admin.js
+++ b/src/website/admin.js
@@ -15,6 +15,7 @@ import { logger } from "../utils/logger.js";
 import { analyseFontsInBatches } from "../utils/read-font-file/analyseFonts.js";
 import { get_bullet, get_generated_static_floders } from "../bootstrap/init.js";
 import { regenerateAllStaticFont } from "../bootstrap/fontNoMin.js";
+import { fontFileName } from "../utils/read-font-file/readFontBuffer.js";
 import { generateCSSMap } from "./generateCSSMap.js";
 
 const redis = new Redis(process.env.REDIS_URL);
@@ -284,14 +285,20 @@ async function updateAdminUserRole(userId, role) {
 	return serializeAdminUser(rows[0]);
 }
 
-async function syncOriginalFontToMinio({ id, weight, extension, buffer }) {
+async function syncOriginalFontToMinio({
+	id,
+	weight,
+	part = 0,
+	extension,
+	buffer,
+}) {
 	if (process.env.SYNC_WITH_MINIO !== "true") return;
 	if (!isMinioConfigured()) {
 		throw new Error("SYNC_WITH_MINIO=true, but MinIO is not configured");
 	}
 
 	const minioClient = createMinioClient();
-	const key = `original-fonts/${id}/${weight}.${extension}`;
+	const key = `original-fonts/${id}/${fontFileName(weight, part, extension)}`;
 	await minioClient.send(
 		new PutObjectCommand({
 			Bucket: process.env.MINIO_BUCKET,
@@ -303,10 +310,10 @@ async function syncOriginalFontToMinio({ id, weight, extension, buffer }) {
 	logger.info(`Synced original font to MinIO: ${key}`);
 }
 
-async function deleteOriginalFontFromMinio({ id, weight, extension }) {
+async function deleteOriginalFontFromMinio({ id, weight, part = 0, extension }) {
 	if (process.env.SYNC_WITH_MINIO !== "true" || !isMinioConfigured()) return;
 	const minioClient = createMinioClient();
-	const key = `original-fonts/${id}/${weight}.${extension}`;
+	const key = `original-fonts/${id}/${fontFileName(weight, part, extension)}`;
 	await minioClient.send(
 		new DeleteObjectCommand({
 			Bucket: process.env.MINIO_BUCKET,
@@ -475,24 +482,54 @@ async function syncCssToMinio({ id, weight, css }) {
 	logger.info(`Synced CSS to MinIO: ${key}`);
 }
 
-async function saveOriginalFontFile({ id, weight, extension, fileBase64 }) {
+async function saveOriginalFontFile({
+	id,
+	weight,
+	part = 0,
+	extension,
+	fileBase64,
+}) {
 	if (process.env.SYNC_WITH_MINIO === "true" && !isMinioConfigured()) {
 		throw new Error("SYNC_WITH_MINIO=true, but MinIO is not configured");
 	}
 	const fontDir = path.join(originalFontsDir, id);
 	const fontBuffer = Buffer.from(fileBase64, "base64");
 
-	await syncOriginalFontToMinio({ id, weight, extension, buffer: fontBuffer });
+	await syncOriginalFontToMinio({
+		id,
+		weight,
+		part,
+		extension,
+		buffer: fontBuffer,
+	});
 	await mkdir(fontDir, { recursive: true });
-	await writeFile(path.join(fontDir, `${weight}.${extension}`), fontBuffer);
+	await writeFile(
+		path.join(fontDir, fontFileName(weight, part, extension)),
+		fontBuffer,
+	);
 
 	for (const oldExtension of fontExtensions) {
 		if (oldExtension === extension) continue;
-		await rm(path.join(fontDir, `${weight}.${oldExtension}`), {
+		await rm(path.join(fontDir, fontFileName(weight, part, oldExtension)), {
 			force: true,
 		});
-		await deleteOriginalFontFromMinio({ id, weight, extension: oldExtension });
+		await deleteOriginalFontFromMinio({
+			id,
+			weight,
+			part,
+			extension: oldExtension,
+		});
 	}
+}
+
+// Split-file index: empty/0 means the primary `<weight>.<ext>`, n >= 1 means `<weight>-<n>.<ext>`.
+function normalizeFontPart(value) {
+	if (value === undefined || value === null || value === "") return 0;
+	const part = Number(value);
+	if (!Number.isInteger(part) || part < 0 || part > 99) {
+		throw new Error("Part must be an integer between 0 and 99");
+	}
+	return part;
 }
 
 function normalizeTextArray(value) {
@@ -524,6 +561,7 @@ function assertUploadPayload(body) {
 	if (!["ttf", "otf"].includes(ext)) {
 		throw new Error("Only ttf and otf fonts are supported");
 	}
+	normalizeFontPart(body.part);
 	if (!allowedCategories.has(body.category)) {
 		throw new Error("Invalid category");
 	}
@@ -588,7 +626,8 @@ function normalizeReplacementFont(body) {
 	if (!fontExtensions.includes(extension)) {
 		throw new Error("Only ttf and otf fonts are supported");
 	}
-	return { weight, extension, fileBase64: body.fileBase64 };
+	const part = normalizeFontPart(body.replacementPart);
+	return { weight, part, extension, fileBase64: body.fileBase64 };
 }
 
 function assertDemoSentencePayload(body) {
@@ -604,6 +643,7 @@ async function saveFontRecord(body) {
 	await saveOriginalFontFile({
 		id,
 		weight,
+		part: normalizeFontPart(body.part),
 		extension,
 		fileBase64: body.fileBase64,
 	});


### PR DESCRIPTION
## 問題

#95 全字庫楷體（以及全字庫明體）一個字重被拆成三個檔案：`TW-Kai`（BMP）、`TW-Kai-Ext-B`、`TW-Kai-Plus`，因為單一 sfnt 最多只能放 65535 個 glyph。目前 emfont 假設「一個字重 = 一個檔案」（`<weight>.ttf`），所以這類字型放不進來。

## 做法

讓一個字重可以由多個檔案組成，輸出端不變（仍然是一個 woff2、一樣的 pack / URL / CSS / MinIO 路徑），只有讀原始字型的地方知道分割檔的存在：

- 檔名規則：主檔 `400.ttf`，其餘分割檔 `400-1.ttf`、`400-2.ttf`…（`-n` 從 1 開始，`400-0.ttf` 不合法）。既有字型檔名不受影響。
- `readFontBuffer.js`
  - `listFontPartFiles` / `parseFontFileName` / `fontFileName`：統一處理分割檔命名
  - `getSupportedChars`：回傳所有分割檔字元的聯集（`init` 分析語言、切靜態字型用）
  - `getFontPartCharSets`：每個分割檔的 code point set，依檔案 size + mtime 快取；只有分割字型才會用到，檔案在讀取途中被換掉時回空陣列而不是丟例外
  - 原本的 `readFontBuffer` 已沒有呼叫端，一併移除
- `makeFont.js` `generateFont`
  - 只有一個檔案 → 跟原本一模一樣，直接 `readFileSync` + `subsetFont`，不會去解析 cmap
  - 多個檔案 → 先算出請求的字分別落在哪些檔案；只落在一個檔案就直接 subset 那個檔案；橫跨多個檔案時，各檔先 subset 成小 TTF，再用 `fonteditor-core` 合併成一個 sfnt，最後照舊輸出 woff2。合併只發生在真的需要時（例如同一個 pack 同時有 BMP 字和 Ext-B 字）
  - `fonteditor-core` 的 `merge()` 會略過沒有輪廓的 glyph（空格、U+3000），合併後會把這些 glyph 補回去，否則對應的 cmap 會消失
  - 找不到字型檔時會 `logger.warn` 帶上 family / weight
- `init.js`：掃描 `original-fonts` 時接受 `400-1.ttf`，字重仍算同一個
- `fontNoMin.js` / `allGlyphs.js`：改用聯集字元
- admin 上傳 / 重新上傳多了選填的「分割檔序號」欄位（`part` / `replacementPart`），本機與 MinIO 檔名同步用 `400-1.ttf` 規則；不填就是原本行為
  - 上傳主檔（序號 0）視為重置該字重，會順便刪掉舊的 `400-n.*`，避免舊分割檔一直被合併進去
  - 序號 ≥ 1 必須已經有主檔才能上傳
  - `font_family.format` 只跟主檔走，分割檔副檔名不同不會影響下載連結

新增依賴：`fonteditor-core`（純 JS，不需要 python / fontforge）。

## 驗證

全字庫楷體 98.1 實檔，放成 `original-fonts/TWKai/400.ttf`（TW-Kai，39204 字）、`400-1.ttf`（Ext-B，49568 字）、`400-2.ttf`（Plus，25080 字）：

| 情境 | 結果 |
|---|---|
| `getSupportedChars` 聯集 | 113650 字 |
| 只請求 BMP 字（`全字庫楷體臺灣測試`） | 9/9 glyph，不走合併，44 ms |
| 只請求 Ext-B 字 | 8/8 glyph，不走合併，34 ms |
| 只請求 Plus 字（PUA 補充區） | 8/8 glyph，不走合併，15 ms |
| 三檔混合 25 字 | 25/25 glyph，合併 64 ms；advance width、bbox、path 指令數與原檔 25/25 相同 |
| 模擬 135 字靜態 pack 三檔混合 | 135/135 glyph，221 ms |
| 沒有任何字型有的字 | 跟原本一樣輸出空字型 |

另外用 fontTools 把一個字型切成「只有漢字」與「其餘字元（含空格、U+3000）」兩檔做 regression：漢字 + 空格混合請求時，空格與 U+3000 都保留且 advance width 與原檔一致。

`pnpm install --frozen-lockfile` 通過。

## 已知取捨

- 只有**橫跨多檔**的請求會走合併；合併結果不保留 GSUB / GPOS / kern / hinting（`fonteditor-core` 的 `kerning: true` 也只能複製 base 檔的原表，跨檔的 GPOS 無法合併）。全字庫本身沒有這些功能，影響不大，但其他分割字型要留意
- OTF（CFF）分割檔走合併時會被轉成二次曲線輪廓
- admin 沒有列出／刪除單一分割檔的介面，靠「重新上傳主檔會重置該字重」處理

## 收錄全字庫的步驟

1. 解壓 `Fonts_Kai.zip`，把 `TW-Kai-98_1.ttf` → `TWKai/400.ttf`、`TW-Kai-Ext-B-98_1.ttf` → `TWKai/400-1.ttf`、`TW-Kai-Plus-98_1.ttf` → `TWKai/400-2.ttf`
2. 放進 MinIO 的 `original-fonts/TWKai/`（或 admin 上傳頁依序上傳，序號填 0 / 1 / 2，主檔要先上傳），然後重新生成靜態字型
3. 全字庫明體 `Fonts_Sung.zip` 同樣方式

Closes #95

P.S. 窩需要全字庫QQ 再麻煩你了謝謝謝謝

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 支持超大字体拆分为多个分片，并按请求字符集合并生成字体。
  * 管理后台支持查看、刷新及批量上传原始字体分片。
  * 新增分片序号设置，支持主文件及 0–99 号分片。

* **改进**
  * 优化字体文件命名、解析、缓存与分片识别，避免重复计数。
  * 增强上传格式、重复文件及分片关系校验。
  * 无法读取字体字符集时提供更明确的错误提示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
